### PR TITLE
Introduce as_u128 method for the Id type.

### DIFF
--- a/src/node/id.rs
+++ b/src/node/id.rs
@@ -44,6 +44,11 @@ impl Id {
         let id = u128::from_le_bytes(bytes);
         Id(id)
     }
+
+    /// return internal representation of the identifier.
+    pub fn as_u128(&self) -> u128 {
+        self.0
+    }
 }
 
 impl From<u128> for Id {


### PR DESCRIPTION
`as_u128` provides an access to the internal representation
of the Id type. This method may be useful for the other libraries
that needs to serialize of convert this type to the internal
ones.