### PR TITLE
Sanitize handling of own node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poldercast"
-version = "0.3.0"
+version = "0.3.1-dev"
 license = "MIT OR Apache-2.0"
 authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>"]
 edition = "2018"

--- a/src/topology/cyclon.rs
+++ b/src/topology/cyclon.rs
@@ -46,13 +46,12 @@ impl Module for Cyclon {
 
     fn select_gossips(
         &self,
-        our_node: &Node,
+        _our_node: &Node,
         gossip_recipient: &Node,
         known_nodes: &BTreeMap<Id, Node>,
     ) -> BTreeMap<Id, Node> {
         let mut candidates = BTreeMap::new();
         let mut rng = rand_os::OsRng::new().unwrap();
-        candidates.insert(*our_node.id(), our_node.clone());
 
         candidates.extend(
             self.select_random_gossips(&mut rng, known_nodes)

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -104,6 +104,14 @@ impl Topology {
                 &self.known_nodes,
             ));
         }
+
+        // Sanitize the gossip if the modules did not:
+        // - the recipient does not need gossip about itself;
+        // - we always include gossip about ourselves,
+        //   with the updated timestamp.
+        gossips.remove(gossip_recipient.id());
+        gossips.insert(*self.our_node.id(), self.our_node.clone());
+
         gossips
     }
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -77,7 +77,10 @@ impl Topology {
     /// This function can be called initially to bootstrap the topology with static
     /// values. But it is intended to be called at every gossips received from
     /// other nodes.
-    pub fn update(&mut self, new_nodes: BTreeMap<Id, Node>) {
+    pub fn update(&mut self, mut new_nodes: BTreeMap<Id, Node>) {
+
+        new_nodes.remove(self.our_node.id());
+
         self.our_node.subscribers.extend(new_nodes.keys());
         self.known_nodes.extend(new_nodes);
 


### PR DESCRIPTION
Prune own node from the topology set considered for propagation.
But make sure our node is always sent in the gossip with the current timestamp.

fixes #2 