### PR TITLE
Add conversion into Multiaddr

### DIFF
--- a/src/node/address.rs
+++ b/src/node/address.rs
@@ -70,6 +70,13 @@ impl From<Multiaddr> for Address {
     }
 }
 
+impl From<Address> for Multiaddr {
+    #[inline]
+    fn from(address: Address) -> Self {
+        address.0
+    }
+}
+
 impl std::str::FromStr for Address {
     type Err = <Multiaddr as std::str::FromStr>::Err;
 


### PR DESCRIPTION
An `Address` should be convertable into a `Multiaddr`, without exposing that `Multiaddr` is the internal representation.