### PR TITLE
Retain Nodes Lifted from Quarantine

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -142,7 +142,7 @@ impl Nodes {
                     quarantined.remove(k);
                     node.logs_mut().lift_quarantine();
 
-                    false
+                    true
                 }
             }
         });


### PR DESCRIPTION
Nodes lifted from quarantine should be retained for further processing. If they are not retained, once lifted from quarantine then they will be returned to the ```available``` or ```not_reachable``` list but never be a candidate for processing again (because they are not in the ```all``` list anymore). Hence, memory will be leaked.

This is the first step to fixing the [100% CPU issue](https://github.com/input-output-hk/jormungandr/issues/1599) in jormungandr.