### PR TITLE
Use parallel unstable sort of nodes in Vicinity layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.7"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+rayon = "1.3.0"
 
 [dev-dependencies]
 rand_chacha = "0.2"

--- a/src/poldercast/vicinity.rs
+++ b/src/poldercast/vicinity.rs
@@ -1,4 +1,5 @@
 use crate::{GossipsBuilder, Id, Layer, Node, NodeProfile, Nodes, ViewBuilder};
+use rayon::prelude::*;
 
 const VICINITY_MAX_VIEW_SIZE: usize = 20;
 const VICINITY_MAX_GOSSIP_LENGTH: usize = 10;
@@ -75,7 +76,8 @@ impl Vicinity {
         mut profiles: Vec<&Node>,
         max: usize,
     ) -> Vec<Id> {
-        profiles.sort_by(|left, right| {
+        // Use unstable parallel sort as total number of nodes can be quite large.
+        profiles.par_sort_unstable_by(|left, right| {
             to.proximity(left.profile())
                 .cmp(&to.proximity(right.profile()))
         });


### PR DESCRIPTION
Sorting of nodes by the Vicinity Layer is an expensive operation. A substantial speed up can be made by using a parallel unstable sort provided by the rayon crate.