### PR TITLE
Added performant node count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use self::{
     logs::Logs,
     node::{Node, NodeInfo, NodeProfile, NodeProfileBuilder},
     nodes::Nodes,
+    nodes::Count,
     policy::{DefaultPolicy, Policy, PolicyReport, Record, Strike, StrikeReason},
     topic::{InterestLevel, Proximity, Subscription, Subscriptions, Topic},
     topology::Topology,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,7 +1,7 @@
 use crate::{Id, Node, Policy, PolicyReport};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-#[derive(Clone, Debug)]
+#[derive(Default, Debug)]
 pub struct Nodes {
     all: HashMap<Id, Node>,
     quarantined: HashSet<Id>,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,14 +1,20 @@
 use crate::{Id, Node, Policy, PolicyReport};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
-#[derive(Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct Nodes {
     all: HashMap<Id, Node>,
-
     quarantined: HashSet<Id>,
-
     not_reachable: BTreeSet<Id>,
     available: BTreeSet<Id>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Count {
+    pub all_count: usize,
+    pub quarantined_count: usize,
+    pub not_reachable_count: usize,
+    pub available_count: usize,
 }
 
 pub enum Entry<'a> {
@@ -93,6 +99,16 @@ impl Nodes {
 
     pub fn quarantined_nodes(&self) -> &HashSet<Id> {
         &self.quarantined
+    }
+
+    /// access a count of all nodes
+    pub fn node_count(&self) -> Count {
+        Count {
+            all_count: self.all.len(),
+            available_count: self.available.len(),
+            not_reachable_count: self.not_reachable.len(),
+            quarantined_count: self.quarantined.len()
+        }
     }
 
     fn insert(&mut self, node: Node) -> Option<Node> {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,5 +1,6 @@
 use crate::{Id, Node, Policy, PolicyReport};
 use std::collections::{BTreeSet, HashMap, HashSet};
+use serde::{Serialize, Deserialize};
 
 #[derive(Default, Debug)]
 pub struct Nodes {
@@ -9,7 +10,7 @@ pub struct Nodes {
     available: BTreeSet<Id>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Count {
     pub all_count: usize,
     pub quarantined_count: usize,


### PR DESCRIPTION
Implement single return function containing node counts. Allows dependents to get node counts in efficient manner (i.e. without iterating over map filtered collections).