### PR TITLE
Additional parallel processing

### DIFF
--- a/src/poldercast/cyclon.rs
+++ b/src/poldercast/cyclon.rs
@@ -24,7 +24,6 @@ impl Cyclon {
     {
         self.0 = known_nodes
             .iter()
-            .map(|v| v)
             .cloned()
             .choose_multiple(&mut rng, capacity);
     }

--- a/src/poldercast/rings.rs
+++ b/src/poldercast/rings.rs
@@ -3,6 +3,7 @@ use crate::{
     Topic, ViewBuilder,
 };
 use std::collections::BTreeMap;
+use rayon::prelude::*;
 
 /// the number of neighbor for a given subscribed topic of the given node.
 ///
@@ -258,7 +259,7 @@ impl Rings {
         // candidates are the one that are common topics.
         let candidates: BTreeMap<Id, &Node> = all_nodes
             .available_nodes()
-            .iter()
+            .par_iter()
             .filter_map(|id| all_nodes.get(id))
             .filter(|node| node.profile().address().is_some())
             .filter(|v| {

--- a/src/poldercast/vicinity.rs
+++ b/src/poldercast/vicinity.rs
@@ -27,7 +27,7 @@ impl Layer for Vicinity {
             identity,
             all_nodes
                 .available_nodes()
-                .iter()
+                .par_iter()
                 .filter(|id| *id != identity.id())
                 .filter_map(|id| all_nodes.get(id))
                 .collect(),
@@ -48,7 +48,7 @@ impl Layer for Vicinity {
                 .profile(),
             all_nodes
                 .available_nodes()
-                .iter()
+                .par_iter()
                 .filter(|id| *id != gossips_builder.recipient())
                 .filter_map(|id| all_nodes.get(id))
                 .collect(),


### PR DESCRIPTION
The change to parallel processing in the vicinity layer made a huge difference to performance. After running another 30 minute benchmark, the sort operation in the Vicinity Layer is no longer the worst performer. Instead, the Cyclon Layer now holds that crown. Expanding on the previous change, I've added some additional parallel processing. Admittedly this still does not "fix" the poldercast implementation. But it definitely contributes to node update and block creation performance.