### PR TITLE
Bump lru dependency version to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 rayon = "1.3.0"
-lru = "^0.4.3"
+lru = "0.6"
 
 [dev-dependencies]
 rand_chacha = "0.2"


### PR DESCRIPTION
This fixes a recent breakage in some dependencies that were eligible for `lru <= 0.5`.