### PR TITLE
Port Address representation to parity-multiaddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poldercast"
-version = "0.13.4"
+version = "0.14.0-dev"
 license = "MIT OR Apache-2.0"
 authors = ["Nicolas Di Prima <nicolas@primetype.co.uk>"]
 edition = "2018"
@@ -13,8 +13,7 @@ Peer to Peer topology management
 """
 
 [dependencies]
-multiaddr = "0.3.1"
-cid = "=0.3.1"
+multiaddr = { package = "parity-multiaddr", version = "0.9.4" }
 rand = "0.7"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,58 +1,38 @@
-use multiaddr::{self, Multiaddr, ToMultiaddr};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::{
-    cmp::{Ord, Ordering},
-    fmt,
-    net::SocketAddr,
-};
-use thiserror::Error;
+use multiaddr::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 /// the address of any given nodes
 ///
 /// The underlying object is, for now, a [`Multiaddr`] to allow
 /// compatibility with the different type of network and identification.
 ///
-/// [`Multiaddr`]: https://docs.rs/multiaddr/latest/multiaddr/struct.Multiaddr.html
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+/// [`Multiaddr`]: https://docs.rs/parity-multiaddr/0.9/parity_multiaddr/struct.Multiaddr.html
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "Multiaddr")]
 pub struct Address(Multiaddr);
 
 impl Address {
-    /// create a new address from any given [`ToMultiaddr`] implementors
-    ///
-    /// # Examples
-    ///
-    /// TODO: simple example with SockAddr from standard lib
-    /// TODO: simple example with a multiaddr object and a string
-    ///
-    /// TODO: [`ToMultiaddr`]
-    pub fn new<Addr>(addr: Addr) -> Result<Self, multiaddr::Error>
-    where
-        Addr: ToMultiaddr,
-    {
-        addr.to_multiaddr().map(Address)
-    }
+    pub fn to_socket_addr(&self) -> Option<SocketAddr> {
+        use multiaddr::Protocol::*;
 
-    #[deprecated(
-        since = "0.12.0",
-        note = "Use the `multi_address` function instead, this function will be removed"
-    )]
-    pub fn to_socketaddr(&self) -> Option<SocketAddr> {
-        let components = self.0.iter().collect::<Vec<_>>();
-
-        match components.get(0)? {
-            multiaddr::AddrComponent::IP4(ipv4) => {
-                if let multiaddr::AddrComponent::TCP(port) = components.get(1)? {
-                    Some(std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
-                        *ipv4, *port,
+        let mut iter = self.0.iter();
+        match iter.next()? {
+            Ip4(ipv4) => {
+                if let Tcp(port) = iter.next()? {
+                    Some(SocketAddr::V4(SocketAddrV4::new(
+                        ipv4, port,
                     )))
                 } else {
                     None
                 }
             }
-            multiaddr::AddrComponent::IP6(ipv6) => {
-                if let multiaddr::AddrComponent::TCP(port) = components.get(1)? {
-                    Some(std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
-                        *ipv6, *port, 0, 0,
+            Ip6(ipv6) => {
+                if let Tcp(port) = iter.next()? {
+                    Some(SocketAddr::V6(SocketAddrV6::new(
+                        ipv6, port, 0, 0,
                     )))
                 } else {
                     None
@@ -62,22 +42,30 @@ impl Address {
         }
     }
 
-    pub fn multi_address(&self) -> &Multiaddr {
+    pub fn multiaddr(&self) -> &Multiaddr {
         &self.0
     }
 
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_bytes()
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
     }
 }
 
-impl From<Multiaddr> for Address {
-    fn from(multiaddr: Multiaddr) -> Self {
-        Address(multiaddr)
+impl From<IpAddr> for Address {
+    fn from(addr: IpAddr) -> Self {
+        Address(addr.into())
+    }
+}
+
+impl From<Ipv4Addr> for Address {
+    fn from(addr: Ipv4Addr) -> Self {
+        Address(addr.into())
+    }
+}
+
+impl From<Ipv6Addr> for Address {
+    fn from(addr: Ipv6Addr) -> Self {
+        Address(addr.into())
     }
 }
 
@@ -88,8 +76,8 @@ impl From<Address> for Multiaddr {
     }
 }
 
-#[derive(Debug, Error)]
-pub enum FromStrAddressError {
+#[derive(Debug, thiserror::Error)]
+pub enum AddressTryFromError {
     #[error("Invalid address format: {source}")]
     Multiaddr {
         #[from]
@@ -98,94 +86,33 @@ pub enum FromStrAddressError {
     },
 
     #[error("Invalid address format, rejecting non ip4 or ip6")]
-    RejectingNonIp4OrIp6thread,
+    UnsupportedProtocol,
+}
+
+impl TryFrom<Multiaddr> for Address {
+    type Error = AddressTryFromError;
+    fn try_from(multiaddr: Multiaddr) -> Result<Self, Self::Error> {
+        use multiaddr::Protocol::*;
+
+        match multiaddr.iter().next() {
+            Some(Ip4(_)) | Some(Ip6(_)) => Ok(Address(multiaddr)),
+            _ => Err(AddressTryFromError::UnsupportedProtocol),
+        }
+    }
 }
 
 impl std::str::FromStr for Address {
-    type Err = FromStrAddressError;
+    type Err = AddressTryFromError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let addr = s.parse().map(Address)?;
-
-        match addr.0.iter().next() {
-            Some(multiaddr::AddrComponent::IP4(_)) => Ok(addr),
-            Some(multiaddr::AddrComponent::IP6(_)) => Ok(addr),
-            _ => Err(FromStrAddressError::RejectingNonIp4OrIp6thread),
-        }
+        let multiaddr = s.parse::<Multiaddr>()?;
+        Address::try_from(multiaddr)
     }
 }
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl PartialOrd for Address {
-    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
-        PartialOrd::partial_cmp(self.0.as_slice(), rhs.0.as_slice())
-    }
-}
-impl Ord for Address {
-    fn cmp(&self, rhs: &Self) -> Ordering {
-        Ord::cmp(self.0.as_slice(), rhs.0.as_slice())
-    }
-}
-
-impl Serialize for Address {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&format!("{}", self))
-        } else {
-            serializer.serialize_bytes(&self.as_slice())
-        }
-    }
-}
-impl<'de> Deserialize<'de> for Address {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::{self, Unexpected, Visitor};
-        use std::fmt::Formatter;
-
-        struct AddressVisitor;
-        impl<'de> Visitor<'de> for AddressVisitor {
-            type Value = Address;
-
-            fn expecting(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
-                write!(
-                    f,
-                    "expected a multi format address (e.g.: `/ip4/127.0.0.1/tcp/8081')"
-                )
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                s.parse::<Address>()
-                    .map_err(|_err| de::Error::invalid_value(Unexpected::Str(s), &self))
-            }
-            fn visit_bytes<E>(self, s: &[u8]) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                match multiaddr::Multiaddr::from_bytes(s.to_owned()) {
-                    Ok(address) => Ok(Address::from(address)),
-                    Err(_err) => Err(de::Error::invalid_value(Unexpected::Bytes(s), &self)),
-                }
-            }
-        }
-
-        if deserializer.is_human_readable() {
-            deserializer.deserialize_str(AddressVisitor)
-        } else {
-            deserializer.deserialize_bytes(AddressVisitor)
-        }
     }
 }
 
@@ -228,7 +155,7 @@ mod test {
         if let Err(err) = parsed {
             assert_eq!(
                 err.to_string(),
-                "invalid value: string \"/dns6/example.com/tcp/2901\", expected expected a multi format address (e.g.: `/ip4/127.0.0.1/tcp/8081\') at line 1 column 28"
+                "Invalid address format, rejecting non ip4 or ip6"
             )
         } else {
             panic!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ mod topology;
 mod view;
 
 pub use self::{
-    address::Address,
+    address::{Address, AddressTryFromError},
     gossip::{Gossips, GossipsBuilder},
     layer::Layer,
     logs::Logs,


### PR DESCRIPTION
The `multiaddr` crate is getting old and its dependencies no longer pass audit.

Besides this immediate problem, switching to `parity-multiaddr` gets us proper `/dns` support.

Restore the `to_socket_addr` method: it's proven more useful than we thought, and there is no equivalent in `Multiaddr` API now.