### PR TITLE
Don't require default features of parity-multiaddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ Peer to Peer topology management
 """
 
 [dependencies]
-multiaddr = { package = "parity-multiaddr", version = "0.9.4" }
+multiaddr = { package = "parity-multiaddr", version = "0.9.6", default-features = false }
 rand = "0.7"
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
URL support has been made optional, so the dependencies needed for it can be shed from the dependency tree as
the poldercast library does not require this feature.