### PR TITLE
Export PriorityMap type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@ mod profiles;
 mod topic;
 mod topology;
 
+pub(crate) use self::profiles::Profiles;
 pub use self::{
     gossip::{Gossip, GossipError, GossipSlice},
+    priority_map::PriorityMap,
     profile::Profile,
     topic::{
         InterestLevel, Subscription, SubscriptionError, SubscriptionIter, SubscriptionSlice,
@@ -19,4 +21,3 @@ pub use self::{
     },
     topology::Topology,
 };
-pub(crate) use self::{priority_map::PriorityMap, profiles::Profiles};


### PR DESCRIPTION
I would like to create my own custom layer for poldercast but this is not possible since the `Layer` trait requires to implement a method that accepts a `PriorityMap` as an argument, while the type is not exposed outside of the crate.
I don't know if I am missing something or this is intended behavior, but here is a PR to fix that in case it's an error.
