### PR TITLE
Expose info on topology

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ mod profiles;
 mod topic;
 mod topology;
 
-pub(crate) use self::profiles::Profiles;
 pub use self::{
     gossip::{Gossip, GossipError, GossipSlice},
     priority_map::PriorityMap,
     profile::Profile,
+    profiles::Profiles,
     topic::{
         InterestLevel, Subscription, SubscriptionError, SubscriptionIter, SubscriptionSlice,
         Subscriptions, SubscriptionsSlice, Topic,

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -4,9 +4,9 @@ use lru::LruCache;
 use std::sync::Arc;
 
 pub struct Profiles {
-    pub dirty: LruCache<ed25519::PublicKey, Arc<Profile>>,
-    pub pool: LruCache<ed25519::PublicKey, Arc<Profile>>,
-    pub trusted: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub(crate) dirty: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub(crate) pool: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub(crate) trusted: LruCache<ed25519::PublicKey, Arc<Profile>>,
 }
 
 impl Profiles {
@@ -16,6 +16,18 @@ impl Profiles {
             pool: LruCache::new(pool),
             trusted: LruCache::new(trusted),
         }
+    }
+
+    pub fn dirty(&self) -> &LruCache<ed25519::PublicKey, Arc<Profile>> {
+        &self.dirty
+    }
+
+    pub fn pool(&self) -> &LruCache<ed25519::PublicKey, Arc<Profile>> {
+        &self.pool
+    }
+
+    pub fn trusted(&self) -> &LruCache<ed25519::PublicKey, Arc<Profile>> {
+        &self.trusted
     }
 
     pub fn promote(&mut self, entry: &ed25519::PublicKey) {

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -4,9 +4,9 @@ use lru::LruCache;
 use std::sync::Arc;
 
 pub struct Profiles {
-    pub(crate) dirty: LruCache<ed25519::PublicKey, Arc<Profile>>,
-    pub(crate) pool: LruCache<ed25519::PublicKey, Arc<Profile>>,
-    pub(crate) trusted: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub dirty: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub pool: LruCache<ed25519::PublicKey, Arc<Profile>>,
+    pub trusted: LruCache<ed25519::PublicKey, Arc<Profile>>,
 }
 
 impl Profiles {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -218,4 +218,8 @@ impl Topology {
     pub fn peers(&self) -> &Profiles {
         &self.profiles
     }
+
+    pub fn self_profile(&self) -> &Profile {
+        &self.profile
+    }
 }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -214,4 +214,8 @@ impl Topology {
     pub fn get(&mut self, id: &ed25519::PublicKey) -> Option<&Arc<Profile>> {
         self.profiles.get(id)
     }
+
+    pub fn peers(&self) -> &Profiles {
+        &self.profiles
+    }
 }


### PR DESCRIPTION
I'm not sure of the process to propose changes to this library, here there are some additions that I find useful, feel free to redirect me to a better place if necessary.

The aim of this PR is to add some methods to expose info on the topology in order to avoid having to double save things that are already handled by this library. For example, the list of peers that are known to the topology is a bit hard to retrieve currently and you would have to store additional information (e.g. save all ids and then use `get` method, but you would have to do that in the correct order to avoid messing with the lru cache), while in practice all the things I need are already present but a little cumbersome to retrieve.