### PR TITLE
Priority map bug: `put` didn't properly remove the previous key

### DIFF
--- a/src/priority_map.rs
+++ b/src/priority_map.rs
@@ -284,6 +284,19 @@ mod tests {
     }
 
     #[test]
+    fn remove() {
+        let mut map = PriorityMap::<u32, String>::new(10);
+
+        let priority = 1;
+        let entry = "entry".to_owned();
+
+        map.put(priority, entry.clone());
+        map.put(priority, entry.clone());
+
+        assert!(map.remove(&entry));
+    }
+
+    #[test]
     fn ignoring_lower_than_lower_bound() {
         let mut map = PriorityMap::<u32, String>::new(5);
         map.put(3, "3".to_owned());

--- a/src/priority_map.rs
+++ b/src/priority_map.rs
@@ -148,6 +148,8 @@ where
             }
         }
 
+        self.remove(&value);
+
         let entry = Entry::new(key, value);
         let mut entry = Box::new(entry);
         let mut entry_ptr: NonNull<Entry<K, V>> = unsafe { NonNull::new_unchecked(entry.as_mut()) };
@@ -155,24 +157,6 @@ where
         let k = KeyRef { k: keyref };
         let keyref: NonNull<V> = unsafe { NonNull::new_unchecked(&mut (entry_ptr.as_mut()).value) };
         let v = KeyRef { k: keyref };
-
-        if let Some(mut prev) = self.by_value.remove(unsafe { v.k.as_ref() }) {
-            let keyref: NonNull<K> = unsafe { NonNull::new_unchecked(&mut prev.key) };
-            let k = KeyRef { k: keyref };
-            let keyref: NonNull<V> = unsafe { NonNull::new_unchecked(&mut prev.value) };
-            let v = KeyRef { k: keyref };
-
-            // if we have updated the priority of the value we need to also change it
-            // in the previous version of the `by_priority`
-            if let btree_map::Entry::Occupied(mut occupied) = self.by_priority.entry(k) {
-                occupied.get_mut().pop(&v);
-
-                // make sure we don't keep empty priority entries
-                if occupied.get().is_empty() {
-                    occupied.remove();
-                }
-            }
-        }
 
         if self.by_value.insert(v, entry).is_some() {
             panic!("the previous entry (if any) should have been removed already");

--- a/src/priority_map.rs
+++ b/src/priority_map.rs
@@ -1,34 +1,31 @@
 use std::{
     borrow::Borrow,
-    cmp::Ordering,
     collections::{btree_map, hash_map::RandomState, BTreeMap, HashMap},
-    fmt,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     ptr::NonNull,
+    rc::Rc,
 };
 
 #[derive(Debug)]
 struct Entry<K, V> {
-    key: K,
-    value: V,
+    key: Rc<K>,
+    value: Rc<V>,
 }
 
-#[doc(hidden)]
-pub struct KeyRef<K> {
-    k: NonNull<K>,
-}
-
-type PriorityGroup<K, V> = lru::LruCache<KeyRef<V>, NonNull<Entry<K, V>>>;
+type PriorityGroup<K, V> = lru::LruCache<Rc<V>, NonNull<Entry<K, V>>>;
 
 pub struct PriorityMap<K, V, H = RandomState> {
-    by_value: HashMap<KeyRef<V>, Box<Entry<K, V>>, H>,
-    by_priority: BTreeMap<KeyRef<K>, PriorityGroup<K, V>>,
+    by_value: HashMap<Rc<V>, Box<Entry<K, V>>, H>,
+    by_priority: BTreeMap<Rc<K>, PriorityGroup<K, V>>,
     cap: usize,
 }
 
 impl<K, V> Entry<K, V> {
     fn new(key: K, value: V) -> Entry<K, V> {
-        Self { key, value }
+        Self {
+            key: Rc::new(key),
+            value: Rc::new(value),
+        }
     }
 }
 
@@ -52,7 +49,7 @@ where
         Self::new_with_map(cap, HashMap::with_capacity_and_hasher(cap, hash_builder))
     }
 
-    fn new_with_map(cap: usize, by_value: HashMap<KeyRef<V>, Box<Entry<K, V>>, H>) -> Self {
+    fn new_with_map(cap: usize, by_value: HashMap<Rc<V>, Box<Entry<K, V>>, H>) -> Self {
         assert!(
             cap > 0,
             "Cannot do much with a cap set to 0, have at least 1 entry or use a different type"
@@ -78,7 +75,7 @@ where
 
     pub fn contains<Q>(&self, k: &Q) -> bool
     where
-        KeyRef<V>: Borrow<Q>,
+        Rc<V>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.by_value.contains_key(k)
@@ -86,14 +83,12 @@ where
 
     pub fn remove<Q>(&mut self, v: &Q) -> bool
     where
-        KeyRef<V>: Borrow<Q>,
+        Rc<V>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        if let Some(mut entry) = self.by_value.remove(v) {
-            let keyref: NonNull<K> = unsafe { NonNull::new_unchecked(&mut entry.key) };
-            let k = KeyRef { k: keyref };
-            let keyref: NonNull<V> = unsafe { NonNull::new_unchecked(&mut entry.value) };
-            let v = KeyRef { k: keyref };
+        if let Some(entry) = self.by_value.remove(v) {
+            let k = entry.key.clone();
+            let v = entry.value.clone();
 
             if let btree_map::Entry::Occupied(mut occupied) = self.by_priority.entry(k) {
                 occupied.get_mut().pop(&v);
@@ -116,13 +111,13 @@ where
             .flat_map(|v| v.iter())
             .map(|(_, v)| {
                 let p = unsafe { v.as_ref() };
-                (&p.key, &p.value)
+                (p.key.borrow(), p.value.borrow())
             })
     }
 
     pub fn get<Q>(&self, k: &Q) -> Option<(&'_ K, &'_ V)>
     where
-        KeyRef<V>: Borrow<Q>,
+        Rc<V>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         let e = self.by_value.get(k)?;
@@ -138,7 +133,7 @@ where
             //
             // if this is the case, return now and don't add the entry
             if let Some((lowest, _)) = self.by_priority.iter().next() {
-                if unsafe { lowest.k.as_ref() } > &key {
+                if lowest.as_ref() > &key {
                     return;
                 }
             }
@@ -152,13 +147,11 @@ where
 
         let entry = Entry::new(key, value);
         let mut entry = Box::new(entry);
-        let mut entry_ptr: NonNull<Entry<K, V>> = unsafe { NonNull::new_unchecked(entry.as_mut()) };
-        let keyref: NonNull<K> = unsafe { NonNull::new_unchecked(&mut (entry_ptr.as_mut()).key) };
-        let k = KeyRef { k: keyref };
-        let keyref: NonNull<V> = unsafe { NonNull::new_unchecked(&mut (entry_ptr.as_mut()).value) };
-        let v = KeyRef { k: keyref };
+        let entry_ptr: NonNull<Entry<K, V>> = unsafe { NonNull::new_unchecked(entry.as_mut()) };
+        let k = entry.key.clone();
+        let v = entry.value.clone();
 
-        if self.by_value.insert(v, entry).is_some() {
+        if self.by_value.insert(v.clone(), entry).is_some() {
             panic!("the previous entry (if any) should have been removed already");
         }
 
@@ -182,15 +175,15 @@ where
         self.cap = cap;
     }
 
-    fn lower_bound(&self) -> Option<KeyRef<K>> {
+    fn lower_bound(&self) -> Option<Rc<K>> {
         if let Some((k, _)) = self.by_priority.iter().next() {
-            Some(KeyRef { k: k.k })
+            Some(k.clone())
         } else {
             None
         }
     }
 
-    pub fn pop_lowest(&mut self) -> Option<(K, V)> {
+    pub fn pop_lowest(&mut self) -> Option<(Rc<K>, Rc<V>)> {
         let k = self.lower_bound()?;
 
         if let btree_map::Entry::Occupied(mut occupied) = self.by_priority.entry(k) {
@@ -215,51 +208,6 @@ where
         self.by_value.clear();
     }
 }
-
-impl<K: fmt::Debug> fmt::Debug for KeyRef<K> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe { self.k.as_ref().fmt(f) }
-    }
-}
-
-impl<K: Hash> Hash for KeyRef<K> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        unsafe { self.k.as_ref().hash(state) }
-    }
-}
-
-impl<K: PartialEq> PartialEq for KeyRef<K> {
-    fn eq(&self, other: &KeyRef<K>) -> bool {
-        unsafe { self.k.as_ref().eq(other.k.as_ref()) }
-    }
-}
-
-impl<K: Eq> Eq for KeyRef<K> {}
-
-impl<K: PartialOrd> PartialOrd for KeyRef<K> {
-    fn partial_cmp(&self, other: &KeyRef<K>) -> Option<Ordering> {
-        unsafe { self.k.as_ref().partial_cmp(other.k.as_ref()) }
-    }
-}
-
-impl<K: Ord> Ord for KeyRef<K> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        unsafe { self.k.as_ref().cmp(other.k.as_ref()) }
-    }
-}
-
-impl<K> Borrow<K> for KeyRef<K> {
-    fn borrow(&self) -> &K {
-        unsafe { self.k.as_ref() }
-    }
-}
-
-impl<K> Clone for KeyRef<K> {
-    fn clone(&self) -> Self {
-        Self { k: self.k }
-    }
-}
-impl<K> Copy for KeyRef<K> {}
 
 unsafe impl<K: Send, V: Send> Send for PriorityMap<K, V> {}
 unsafe impl<K: Sync, V: Sync> Sync for PriorityMap<K, V> {}
@@ -291,14 +239,18 @@ mod tests {
         let mut map = PriorityMap::<u32, String>::new(10);
 
         let priority = 1;
-        let entry = "entry".to_owned();
+        let entry1 = "entry1".to_owned();
+        let entry2 = "entry2".to_owned();
 
-        map.put(priority, entry.clone());
-        dbg!(&map.by_value);
-        map.put(priority, entry.clone());
-        dbg!(&map.by_value);
+        map.put(priority, entry1.clone());
+        map.put(priority, entry1.clone());
 
-        assert!(map.remove(&entry));
+        assert!(map.remove(&entry1));
+
+        map.put(priority, entry1);
+        map.put(priority, entry2.clone());
+
+        assert!(map.remove(&entry2));
     }
 
     #[test]


### PR DESCRIPTION
inserting twice the same entry generated an invalid state in the `by_value` HashMap.

The issue was that the `HashMap::insert` will not replace the `key` if the value is already present. So we ended up keeping a pointer to something we would then remove after.

This is not the most optimal way but it as the merit to fix the issue simply. Early optimisation led to this issue originally.

thanks @Zeegomo for reporting the issue to me in the first place.